### PR TITLE
Handle non-ASCII URIs

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -20,7 +20,7 @@ module RequestHelper
     # Too many HTTP redirects, abandoning
     return '' if limit == 0
 
-    url = URI.parse(uri_str)
+    url = URI.parse(URI.escape(uri_str))
     req = Net::HTTP::Get.new(url)
     req['Accept'] = 'text/html'
     response = Net::HTTP.start(url.host, url.port, use_ssl: true) { |http| http.request(req) }

--- a/app/views/articles/list.html.erb
+++ b/app/views/articles/list.html.erb
@@ -16,7 +16,7 @@
           <div class="flex-1">
             <div><a class="article-title" target="_blank" href="<%= article.url %>"><%= article.title || article.url %></a></div>
             <div class="article-timestamp">
-              <%= URI.parse(article.url).host %>
+              <%= URI.parse(URI.escape(article.url)).host %>
               &middot;
               added <%= time_ago_in_words(article.created_at) %> ago
             </div>

--- a/test/helpers/request_helper_test.rb
+++ b/test/helpers/request_helper_test.rb
@@ -24,4 +24,10 @@ class RequestHelperTest < ActiveSupport::TestCase
     actual = RequestHelper.url_from_param('https://google.com')
     assert_equal expected, actual
   end
+
+  test '.url_from_param decodes non-ASCII URIs' do
+    expected = "https://www.nexojornal.com.br/expresso/2020/04/09/A-confissão-da-Ecovias-sobre-contratos-com-o-governo-paulista"
+    actual = RequestHelper.url_from_param('https://www.nexojornal.com.br/expresso/2020/04/09/A-confiss%C3%A3o-da-Ecovias-sobre-contratos-com-o-governo-paulista')
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/freshreader/core/issues/51.

This PR adds support for URIs containing non-ASCII characters, e.g.:

```
https://www.nexojornal.com.br/expresso/2020/04/09/A-confiss%C3%A3o-da-Ecovias-sobre-contratos-com-o-governo-paulista
```

Before this PR, trying to save this URI would fail with `URI::InvalidURIError: URI must be ascii only`.