### PR TITLE
Show exception in flash upon save error

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -56,8 +56,8 @@ class ArticlesController < ApplicationController
       flash[:error] = new_article.errors.full_messages.to_sentence
     end
     redirect_to :articles
-  rescue
-    flash[:error] = 'There was an issue saving this URL.'
+  rescue => e
+    flash[:error] = "There was an issue saving this URL: #{e}."
     redirect_to :articles
   end
 


### PR DESCRIPTION
This PR exposes the exception raised when failing to save a URL.

I'm aware that this is not a best practice, but in this low-risk context, it's highly unlikely that this can be used maliciously. The benefit/cost ratio is high here.