### PR TITLE
Revert "Add Firefox 75 on Windows 10 user-agent for requests"

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -23,7 +23,6 @@ module RequestHelper
     url = URI.parse(URI.escape(uri_str))
     req = Net::HTTP::Get.new(url)
     req['Accept'] = 'text/html'
-    req['User-Agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:75.0) Gecko/20100101 Firefox/75.0'
     response = Net::HTTP.start(url.host, url.port, use_ssl: true) { |http| http.request(req) }
 
     case response


### PR DESCRIPTION
Reverts freshreader/core#55

This was causing servers to return JavaScript-enabled pages, which sometimes include generic `<title>` tags.