### PR TITLE
Add API v1 endpoints

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,34 @@
+class Api::V1::ArticlesController < Api::V1::BaseController
+  def index
+    articles = Article.where(user: current_user).sort_by(&:created_at).reverse
+    render json: articles
+  end
+
+  def create
+    ActiveRecord::Base.transaction do
+      url = RequestHelper.url_from_param(params[:url])
+      title = RequestHelper.extract_title_from_page(url)
+
+      new_article = Article.new(user: current_user, url: url, title: title)
+
+      if new_article.save
+        render json: new_article, status: :created
+      else
+        render json: new_article.errors, status: :unprocessable_entity
+      end
+    end
+  rescue
+    render json: "There was an issue saving this URL.", status: :unprocessable_entity
+  end
+
+  def destroy
+    article = Article.find(params[:id])
+
+    if article.destroy
+      head :no_content
+    else
+      render json: article.errors, status: :internal_server_error
+    end
+  end
+end
+

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  module V1
+    class BaseController < ActionController::Base
+      before_action :authenticate
+      protect_from_forgery with: :null_session
+
+      private
+
+      def authenticate
+        authenticate_or_request_with_http_token do |provided_token, options|
+          return unless user = User.find_by(account_number: options[:account_number])
+
+          if valid_auth_token?(user, provided_token)
+            user
+          else
+            # Maybe the auth token is expired, let's generate a new one for clients to use
+            user.regenerate_api_auth_token_if_expired!
+            false
+          end
+        end
+      end
+
+      def valid_auth_token?(user, provided_token)
+        user &&
+          user.api_auth_token_expires_at > Time.now &&
+          ActiveSupport::SecurityUtils.secure_compare(user.api_auth_token, provided_token)
+      end
+
+      def current_user
+        @current_user ||= authenticate
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,38 @@
+class Api::V1::UsersController < Api::V1::BaseController
+  skip_before_action :authenticate, only: [:show, :create]
+
+  def show
+    user = User.find_by(account_number: params[:account_number])
+
+    if user
+      user.regenerate_api_auth_token_if_expired!
+      render json: user
+    else
+      render json: {}, status: :not_found
+    end
+  end
+
+  def create
+    user = User.new(
+      account_number: User.generate_account_number,
+      api_auth_token: User.generate_api_auth_token,
+      api_auth_token_expires_at: Time.now + 30.second,
+    )
+
+    if user.save
+      render json: user, status: :created
+    else
+      render json: user.errors, status: :internal_server_error
+    end
+  end
+
+  def destroy
+    user = current_user
+    if user.destroy
+      head :no_content
+    else
+      render json: user.errors, status: :internal_server_error
+    end
+  end
+end
+

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,15 @@
 class Article < ApplicationRecord
   belongs_to :user
   validates :url, presence: true, url: true
+
+  include ActiveModel::Serializers::JSON
+
+  def attributes
+    {
+      'id' => id,
+      'title' => title,
+      'url' => url,
+      'created_at' => created_at,
+    }
+  end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -60,6 +60,12 @@ class Rack::Attack
     end
   end
 
+  throttle("api/v1/users", limit: 5, period: 60.seconds) do |req|
+    if req.path.include?('/api/v1/users')
+      req.ip
+    end
+  end
+
   ### Custom Throttle Response ###
 
   # By default, Rack::Attack returns an HTTP 429 for throttled responses,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,21 @@
 Rails.application.routes.draw do
+  # API routes
+  namespace :api do
+    namespace :v1 do
+      # Articles
+      get '/articles', to: 'articles#index'
+      post '/articles', to: 'articles#create'
+      delete '/articles/:id', to: 'articles#destroy'
+
+      # Users
+      get '/users/:account_number', to: 'users#show'
+      post '/users', to: 'users#create'
+      delete '/users', to: 'users#destroy'
+    end
+  end
+
+  # Legacy routes
+
   resources :articles
 
   get '/save', to: 'articles#save_bookmarklet', as: :save_bookmarklet

--- a/db/migrate/20200503164250_add_api_auth_token_to_user.rb
+++ b/db/migrate/20200503164250_add_api_auth_token_to_user.rb
@@ -1,0 +1,6 @@
+class AddApiAuthTokenToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :api_auth_token, :string
+    add_column :users, :api_auth_token_expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_15_203723) do
+ActiveRecord::Schema.define(version: 2020_05_03_164250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,8 @@ ActiveRecord::Schema.define(version: 2020_03_15_203723) do
     t.string "account_number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "api_auth_token"
+    t.datetime "api_auth_token_expires_at"
   end
 
   add_foreign_key "articles", "users"

--- a/test/controllers/api/v1/articles_controller_test.rb
+++ b/test/controllers/api/v1/articles_controller_test.rb
@@ -1,0 +1,111 @@
+class ArticlesControllerTest < ActionDispatch::IntegrationTest
+	setup do
+    @user = create_user
+    @credentials = authenticate(@user.api_auth_token, @user.account_number)
+	end
+
+  teardown do
+    User.destroy_all
+  end
+
+  def test_get_articles_without_authentication_returns_401
+    get "/api/v1/articles"
+    assert_response(:unauthorized)
+    assert_equal('HTTP Token: Access denied.', response.body.strip)
+  end
+
+  def test_get_articles_when_authenticated
+    get "/api/v1/articles", headers: { "Authorization" => @credentials }
+    assert_response(:success)
+    assert_equal([], JSON.parse(response.body))
+  end
+
+  def test_insert_article_then_get_all_articles_when_authenticated
+    get "/api/v1/articles", headers: { "Authorization" => @credentials }
+    assert_response(:success)
+    assert_equal([], JSON.parse(response.body))
+
+    post(
+      '/api/v1/articles',
+      params: { url: 'https://example.com/' },
+      headers: { "Authorization" => @credentials },
+    )
+    assert_response(:created)
+
+    get "/api/v1/articles", headers: { "Authorization" => @credentials }
+    assert_response(:success)
+
+    articles = JSON.parse(response.body)
+    assert_equal(1, articles.size)
+
+    saved_article = articles.first
+    assert_equal(['id', 'title', 'url', 'created_at'], saved_article.keys)
+    assert_equal('Example Domain', saved_article['title'])
+    assert_equal('https://example.com/', saved_article['url'])
+  end
+
+  def test_save_invalid_url_returns_422
+    assert_no_difference('Article.count') do
+      post('/api/v1/articles', params: { article: { url: 'http' } }, headers: { "Authorization" => @credentials })
+      assert_response(:unprocessable_entity)
+    end
+  end
+
+  def test_save_empty_url_returns_422
+    assert_no_difference('Article.count') do
+      post('/api/v1/articles', params: { article: { url: '     ' } }, headers: { "Authorization" => @credentials })
+      assert_response(:unprocessable_entity)
+    end
+  end
+
+  def test_save_valid_url_succeeds
+    assert_difference('Article.count') do
+      post(
+        '/api/v1/articles',
+        params: { url: 'https://maximevaillancourt.com/why-i-use-a-thinkpad-x220-in-2019'},
+        headers: { "Authorization" => @credentials },
+      )
+      assert_response(:created)
+    end
+  end
+
+  def test_delete_existing_article_succeeds
+    inserted_article = assert_difference('Article.count', 1) do
+      post(
+        '/api/v1/articles',
+        params: { url: 'https://example.com/' },
+        headers: { "Authorization" => @credentials },
+      )
+      assert_response(:created)
+      Article.last
+    end
+
+    assert_equal(1, Article.count)
+
+    assert_difference('Article.count', -1) do
+      delete(
+        "/api/v1/articles/#{inserted_article.id}",
+        headers: { "Authorization" => @credentials },
+      )
+      assert_response(:no_content)
+    end
+
+    assert_equal(0, Article.count)
+  end
+
+	private
+
+  def authenticate(token, account_number)
+    ActionController::HttpAuthentication::Token.encode_credentials(token, account_number: account_number)
+  end
+
+  def create_user
+    user = User.new(
+      account_number: '1234123412341234',
+      api_auth_token: '12345',
+      api_auth_token_expires_at: Time.now + 10.minute
+    )
+    user.save
+    user
+  end
+end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,0 +1,73 @@
+class UsersControllerTest < ActionDispatch::IntegrationTest
+	setup do
+    @user = create_user
+    @credentials = authenticate(@user.api_auth_token, @user.account_number)
+	end
+
+  teardown do
+    User.destroy_all
+  end
+
+  def test_get_non_existing_user
+    get "/api/v1/users/0001234"
+    assert_response(:not_found)
+    assert_equal({}, JSON.parse(response.body))
+  end
+
+  def test_get_existing_user
+    get "/api/v1/users/#{@user.account_number}"
+    assert_response(:success)
+    user_json = JSON.parse(response.body)
+    assert_equal(@user.account_number, user_json['account_number'])
+  end
+
+  def test_create_user_succeeds
+    assert_difference('User.count', 1) do
+      post "/api/v1/users/"
+      assert_response(:created)
+      user_json = JSON.parse(response.body)
+      assert_equal(['id', 'account_number', 'api_auth_token'], user_json.keys)
+      assert_not_equal('', user_json['id'])
+      assert_not_equal('', user_json['account_number'])
+      assert_not_equal('', user_json['api_auth_token'])
+    end
+  end
+
+  def test_delete_account_succeeds
+    other_user = User.new(
+      account_number: '7777666655554444',
+      api_auth_token: '11111',
+      api_auth_token_expires_at: Time.now + 10.minute
+    )
+    other_user.save
+
+    assert_equal(2, User.count)
+
+    delete(
+      "/api/v1/users",
+      headers: { "Authorization" => @credentials },
+    )
+    assert_response(:no_content)
+
+    assert_equal(1, User.count)
+
+    assert_includes(User.all, other_user)
+    refute_includes(User.all, @user)
+  end
+
+	private
+
+  def authenticate(token, account_number)
+    ActionController::HttpAuthentication::Token.encode_credentials(token, account_number: account_number)
+  end
+
+  def create_user
+    user = User.new(
+      account_number: '1234123412341234',
+      api_auth_token: '12345',
+      api_auth_token_expires_at: Time.now + 10.minute
+    )
+    user.save
+    user
+  end
+end


### PR DESCRIPTION
This PR adds a handful of basic API endpoints for use with https://github.com/freshreader/android.

A few words about the API auth token introduced in this PR:
- The `account_number` value generated for each user on account generation is a 16-digit number, so there are 10,000,000,000,000,000 potential `account_number` values. The odds that someone can find someone else's account number is quite low. This, in itself, is a strong enough property of the application.
- The application does not store private data other than URIs saved by the users. The application doesn't require an email address, nor does it ask for a name, or even a username/alias. The only information stored about users themselves is their account number. All this to say: even in the scenario where a malicious would get ahold of a raw database dump, they would only find URIs and account numbers.
- The API auth token is merely an additional layer of authentication to allow expiring the tokens in case something were to go wrong with the authentication mechanism.