### PR TITLE
Handle relative redirection locations

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -48,7 +48,15 @@ module RequestHelper
 
     case response
     when Net::HTTPOK then response
-    when Net::HTTPRedirection then do_fetch(response['location'], limit: limit - 1)
+    when Net::HTTPRedirection then
+      location_header_value = response['location']
+      redirect_url = if location_header_value.start_with?('/')
+        "#{use_ssl ? 'https://' : 'http://'}#{url.host}#{location_header_value}"
+      else
+        location_header_value
+      end
+
+      do_fetch(redirect_url, limit: limit - 1)
     else
       response.error!
     end

--- a/test/helpers/request_helper_test.rb
+++ b/test/helpers/request_helper_test.rb
@@ -50,4 +50,14 @@ class RequestHelperTest < ActiveSupport::TestCase
     assert_equal expected_title, actual_title
     assert_equal expected_uri, actual_uri.to_s
   end
+
+  test '.extract_title_from_page handles relative redirections' do
+    expected_title = "A Short History of Bi-Directional Links"
+    expected_uri = "https://maggieappleton.com/bidirectionals/"
+
+    actual_title, actual_uri = RequestHelper.extract_title_from_page('https://maggieappleton.com/bidirectionals')
+
+    assert_equal expected_title, actual_title
+    assert_equal expected_uri, actual_uri.to_s
+  end
 end


### PR DESCRIPTION
`https://maggieappleton.com/bidirectionals` returns a 301 redirect with the following `location` header value: `/bidirectionals/`. This PR handles such relative redirection locations.