### PR TITLE
Preserve URL to save when logged out to save after logging in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,11 @@ class SessionsController < ApplicationController
   def create
     if @user = User.find_by(account_number: params[:account_number].delete(' '))
       session[:user_id] = @user.id
-      redirect_to :articles
+      if params[:return_to]
+        redirect_to params[:return_to]
+      else
+        redirect_to :articles
+      end
     else
       redirect_to :login, flash: { error: "This account number does not exist." }
     end

--- a/app/views/sessions/login.html.erb
+++ b/app/views/sessions/login.html.erb
@@ -2,6 +2,8 @@
   <h1>Login</h1>
   <%= form_tag '/login' do %>
     <%= label_tag :account_number, 'Account number', class: 'url-input-label' %>
+
+    <input type="hidden" id="return_to" name="return_to" value="<%= params[:return_to] %>" />
     <div class="flex">
       <%= text_field_tag :account_number, "", placeholder: '0000 0000 0000 0000', class: "flex-1", autofocus: 'autofocus' %>
       <%= submit_tag "Login", class: 'btn-input-group btn-success no-margin' %>

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -143,6 +143,24 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_save_article_when_logged_out_redirects_to_login_then_saves
+    user = create_user(account_number: '1234123412341234')
+
+    assert_no_difference('Article.count') do
+      get(save_bookmarklet_url, params: { url: 'https://freshreader.app' })
+      assert_redirected_to("http://www.example.com/login?return_to=#{CGI.escape('http://www.example.com/save?url=https://freshreader.app')}")
+    end
+
+    assert_difference('Article.count', 1) do
+      post(login_url, params: {
+        account_number: user.account_number,
+        return_to: '/save?url=https://freshreader.app'
+      })
+      assert_redirected_to('http://www.example.com/save?url=https://freshreader.app')
+      get('http://www.example.com/save?url=https://freshreader.app')
+    end
+  end
+
   private
 
   def create_user(account_number:, is_subscribed: true, is_early_adopter: false)


### PR DESCRIPTION
Closes https://github.com/freshreader/core/issues/96

Previously, when a logged out user would try to save a URL, we would simply redirect them to the login page for them to log in, but we wouldn't actually saving the URL after they did log in.

This pull request fixes this by now keeping track of the URL to save while they log in so that we can then save the URL they initially tried to save when they were logged out.