### PR TITLE
Reduce article limit to 3 on free plan

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,5 @@
 class Article < ApplicationRecord
-  ARTICLES_LIMIT_ON_FREE_PLAN = 10
+  ARTICLES_LIMIT_ON_FREE_PLAN = 3
 
   belongs_to :user
   validates :url, presence: true, url: true


### PR DESCRIPTION
Freshreader is currently not profitable ($0 revenue, $7/month expenses) and needs revenue to keep going. This is a first step in that direction.