### PR TITLE
Fix login redirect to articles list

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
   def create
     if @user = User.find_by(account_number: params[:account_number].delete(' '))
       session[:user_id] = @user.id
-      if params[:return_to]
+      if params[:return_to].present?
         redirect_to params[:return_to]
       else
         redirect_to :articles

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -15,6 +15,14 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to(:articles)
   end
 
+  def test_login_succeeds_with_valid_account_number_and_empty_return_to_param
+    user = User.new(account_number: '1234123412341234')
+    user.save
+    post(login_url, params: { return_to: '  ', account_number: user.account_number })
+
+    assert_redirected_to(:articles)
+  end
+
   def test_login_fails_with_non_existent_account_number
     user = User.new(account_number: '1234123412341234')
     user.save


### PR DESCRIPTION
This pull request fixes the redirect logic that happens after logging in.

Without this pull request, a person logging into their account gets redirected to the Freshreader public home page.

With this pull request, a person logging into their account gets redirected to their reading list.

The bug fix consists of adding a `present?` call on `params[:return_to]`, which may be an empty string.